### PR TITLE
#120 이슈 해결

### DIFF
--- a/src/Components/LeaveComments/LeaveCommentPresenter.tsx
+++ b/src/Components/LeaveComments/LeaveCommentPresenter.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { Link } from "react-router-dom";
+import { useHistory } from "react-router-dom";
 import * as I from "../../Asset/SVG/index";
 import * as S from "./styles";
 import IssueBoxPresenter from "../IssueBox/IssueBoxPresenter";
@@ -10,6 +10,7 @@ import Config from "Constants/Config.json";
 const LeaveCommentsPage: React.FC = () => {
   const list = useViewTable();
   const [content, setContent] = useState("");
+  const history = useHistory();
 
   const list3 = list.slice(0, list.length * (1 / 3));
   const list2 = list.slice(list.length * (1 / 3), list.length * (2 / 3));
@@ -39,15 +40,15 @@ const LeaveCommentsPage: React.FC = () => {
             등 록
           </S.Btn>
         </S.Form>
-        <S.Top10Btn>
+        <S.Top10Btn onClick={() => history.push(Config.LINK.TOP10)}>
           <span>
             많은 학생들이 공감한
             <br /> 불편함은 무엇일까요?
           </span>
-          <Link to={Config.LINK.TOP10}>
+          <S.LinkWrapper>
             <span>Top 10 보러가기</span>
             <I.RightArrow />
-          </Link>
+          </S.LinkWrapper>
         </S.Top10Btn>
       </S.LeftBox>
       <S.RightBox>

--- a/src/Components/LeaveComments/styles.tsx
+++ b/src/Components/LeaveComments/styles.tsx
@@ -90,17 +90,9 @@ export const Top10Btn = styled.button`
   width: 328px;
   margin-top: 24px;
   border-radius: 10px;
-  a {
-    color: white;
-    text-decoration: #fff 1px underline;
-    padding-top: 3%;
-    font-size: 12px;
-    font-weight: 600;
-  }
   span {
     padding-right: 9px;
   }
-
   @media ${device.tablet} {
     width: 280px;
     flex-direction: column;
@@ -112,6 +104,14 @@ export const Top10Btn = styled.button`
     flex-direction: row;
   }
 `;
+
+export const LinkWrapper = styled.div`
+  color: white;
+  text-decoration: #fff 1px underline;
+  padding-top: 3%;
+  font-size: 12px;
+  font-weight: 600;
+`
 
 export const RightBox = styled.div`
   display: grid;

--- a/src/Components/Top10Page/Top10Presenter.tsx
+++ b/src/Components/Top10Page/Top10Presenter.tsx
@@ -1,5 +1,5 @@
 import { PageExplanation } from "../PageExplanation";
-import { Link } from "react-router-dom";
+import { useHistory } from "react-router-dom";
 import { LeftBox } from "../../Constants/GlobalStyle/Detail";
 import GoodBtn from "../GoodBtn/GoodBtnPresenter";
 import * as S from "./styled";
@@ -19,6 +19,7 @@ const Top10Page = () => {
   const list = useTop10();
   const modal = useModal();
   const logged = useRecoilValue(HasAdminToken);
+  const history = useHistory();
 
   return (
     <S.TopTenWrapper>
@@ -28,9 +29,9 @@ const Top10Page = () => {
           explanation={explanation}
         />
         {!logged && (
-          <S.Btn>
-            <Link to={Config.LINK.COMMENT}>의견 남기기</Link>
-          </S.Btn>
+          <S.LinkCommentPageBtn onClick={() => history.push(Config.LINK.COMMENT)}>
+            의견 남기기
+          </S.LinkCommentPageBtn>
         )}
       </LeftBox>
       <S.RightBox>

--- a/src/Components/Top10Page/styled.tsx
+++ b/src/Components/Top10Page/styled.tsx
@@ -10,7 +10,7 @@ export const TopTenWrapper = styled.section`
     flex-direction: column;
     width: 90vw;
   }
-`; // left박스와 right박스 전체를 감싸는 wrapper입니다.
+`;
 
 export const RightBox = styled.section`
   width: 54.2%;
@@ -19,7 +19,6 @@ export const RightBox = styled.section`
     width: 100%;
   }
 `;
-// topten 리스트가 적히는 오른쪽 박스입니다.
 
 export const TenIssues = styled.div`
   display: flex;
@@ -95,10 +94,8 @@ export const TenIssues = styled.div`
   }
 `;
 
-export const Btn = styled.button`
+export const LinkCommentPageBtn = styled.button`
   margin-top: 50px;
   background-color: #434c9c;
-  a {
-    color: white;
-  }
+  color: white;
 `;

--- a/src/Components/improvment/improvmentPresenter.tsx
+++ b/src/Components/improvment/improvmentPresenter.tsx
@@ -1,5 +1,5 @@
 import { PageExplanation } from "../PageExplanation";
-import { Link } from "react-router-dom";
+import { useHistory } from "react-router-dom";
 import ImprovmentItemPresenter from "./improvmentItem/improvmentItemPresenter";
 import { useState, useEffect } from "react";
 import { improvement, list } from "./imporvmentContainer";
@@ -15,6 +15,7 @@ const ImprovmentPage: React.FC = () => {
   const [list, setList] = useState<list[]>([]);
   const modal = useModal();
   const logged = useRecoilValue(HasAdminToken);
+  const history = useHistory();
 
   useEffect(() => {
     improvement().then((res) => setList(res.data.list));
@@ -37,13 +38,13 @@ const ImprovmentPage: React.FC = () => {
             </span>
           </S.Btn>
         ) : (
-          <S.Btn>
+          <S.Btn onClick={() => history.push(Config.LINK.COMMENT)}>
             학교가 불편한 순간을
             <br /> 자유롭게 남겨주세요.
-            <Link to={Config.LINK.COMMENT}>
-              의견 남기기
-              <I.RightArrow />
-            </Link>
+              <S.LinkTextWrapper>
+                <span>의견 남기기</span>
+                <I.RightArrow />
+              </S.LinkTextWrapper>
           </S.Btn>
         )}
       </S.LeftBox>

--- a/src/Components/improvment/styled.ts
+++ b/src/Components/improvment/styled.ts
@@ -37,17 +37,18 @@ export const Btn = styled.button`
   @media ${device.mobile} {
     width: 100%;
   }
-  a {
-    align-self: center;
-    font-size: 12px;
-    font-weight: 500;
-    color: white;
-    text-decoration: underline;
-  }
   svg {
     padding-left: 5px;
   }
 `;
+
+export const LinkTextWrapper = styled.div`
+  color: white;
+  text-decoration: #fff 1px underline;
+  padding-top: 3%;
+  font-size: 12px;
+  font-weight: 600;
+`
 
 export const AltImprovementItem = styled.div`
   width: 33.4vw;


### PR DESCRIPTION
기존에는 버튼 박스안에 `react-router`의 `LINK`를 이용하여 텍스트를 감싸서 라우팅하는 방식이라 텍스트를 클릭하였을때만 이것이 적용되었습니다.
![2021-06-08_20-52-18](https://user-images.githubusercontent.com/60869316/121180108-6f6f8e00-c89b-11eb-9fa2-7351ab59e349.png)
또한 스타일 컴포넌트에도 `LINK`가 `anchor`태그로 치환된다는 점을 이용하여 스타일링 하였는데 이 점은 좋지 않은 스타일 방식이라 생각되어 제거 했습니다.
그래서 수정 코드에서는 `react-router`의 `useHistory`훅을 이용하여
```js
const history = useHistory();

return (
    <Button onClick={() => history.push("가고 싶은곳")}>
        이것은 예시코드입니다.
    </Button>
)
```
위의 예시코드와 같이 onClick에 history.push로 라우팅을 시켰습니다.

> 그리고 쓸모없는 주석을 삭제했습니다.
